### PR TITLE
Allow building against GUPnP 1.2 and GSSDP 1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,15 +15,17 @@ set(CMAKE_C_FLAGS "-std=gnu99 -g")
 
 add_definitions(-DRESDIR='"${PROJECT_SOURCE_DIR}/res"' -DGETTEXT_PACKAGE='"camsync"' -DLOCALEDIR='"${CMAKE_INSTALL_FULL_LOCALEDIR}"')
 pkg_check_modules(GLIB REQUIRED glib-2.0 gobject-2.0)
-pkg_check_modules(GUPNP REQUIRED gupnp-1.0 gssdp-1.0 gupnp-av-1.0)
+pkg_search_module(GUPNP REQUIRED gupnp-1.2 gupnp-1.0)
+pkg_search_module(GSSDP REQUIRED gssdp-1.2 gssdp-1.0)
+pkg_check_modules(GUPNP_AV REQUIRED gupnp-av-1.0)
 pkg_search_module(LIBSOUP REQUIRED libsoup-2.4 libsoup-2.2)
 pkg_check_modules(SQLITE REQUIRED sqlite3)
 pkg_check_modules(LIBDAEMON REQUIRED libdaemon)
 
 
-include_directories(${GLIB_INCLUDE_DIRS} ${GUPNP_INCLUDE_DIRS} ${LIBSOUP_INCLUDE_DIRS} ${SQLITE_INCLUDE_DIRS} ${LIBDAEMON_INCLUDE_DIRS})
-link_libraries(${GLIB_LIBRARIES} ${GUPNP_LIBRARIES} ${LIBSOUP_LIBRARIES} ${SQLITE_LIBRARIES} ${LIBDAEMON_LIBRARIES})
-link_directories(${GLIB_LIBRARY_DIRS} ${GUPNP_LIBRARY_DIRS} ${LIBSOUP_LIBRARY_DIRS} ${SQLITE_LIBRARY_DIRS} ${LIBDAEMON_LIBRARY_DIRS})
+include_directories(${GLIB_INCLUDE_DIRS} ${GUPNP_INCLUDE_DIRS} ${GSSDP_INCLUDE_DIRS} ${GUPNP_AV_INCLUDE_DIRS} ${LIBSOUP_INCLUDE_DIRS} ${SQLITE_INCLUDE_DIRS} ${LIBDAEMON_INCLUDE_DIRS})
+link_libraries(${GLIB_LIBRARIES} ${GUPNP_LIBRARIES} ${GSSDP_LIBRARIES} ${GUPNP_AV_LIBRARIES} ${LIBSOUP_LIBRARIES} ${SQLITE_LIBRARIES} ${LIBDAEMON_LIBRARIES})
+link_directories(${GLIB_LIBRARY_DIRS} ${GUPNP_LIBRARY_DIRS} ${GSSDP_LIBRARY_DIRS} ${GUPNP_AV_LIBRARY_DIRS} ${LIBSOUP_LIBRARY_DIRS} ${SQLITE_LIBRARY_DIRS} ${LIBDAEMON_LIBRARY_DIRS})
 
 add_executable(camsync src/camsync.c src/browse.c src/download.c src/jobqueue.c src/config.c src/daemon.c src/logging.c)
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ Canon EOS 70D
 
 Known Working Platforms
 -----------------------
+Debian 11
 Fedora 20
 ReadyNAS Ultra 4 (RAIDiator 4.2.26, with root access enabled)
 
 
 Building
 --------
-To build camsync on Fedora do the following:
+To build camsync on Debian or Fedora do the following:
 ```
 mkdir build
 cd build

--- a/src/camsync.c
+++ b/src/camsync.c
@@ -27,6 +27,7 @@
 #include "daemon.h"
 #include "logging.h"
 
+#include <libgupnp/gupnp-context-manager.h>
 #include <libgupnp/gupnp-control-point.h>
 #include <libgupnp-av/gupnp-av.h>
 #include <string.h>


### PR DESCRIPTION
Please note I didn't test that building against GUPnP 1.0 and GSSDP 1.0 still works. Please verify if you still have that setup available.